### PR TITLE
Set NEXT_PUBLIC_ADS_DEFAULT_URL build-time env var

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 NEXT_PUBLIC_BASE_PATH = /scan
+NEXT_PUBLIC_ADS_DEFAULT_URL = https://ui.adsabs.harvard.edu


### PR DESCRIPTION
Without this, Link components that use NEXT_PUBLIC_ADS_DEFAULT_URL as their href (Navbar, manifest page) receive undefined at build time, causing a Next.js SSR crash on every page render.